### PR TITLE
fix: fix circuitbreaker-logger

### DIFF
--- a/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-2021-plugin/src/main/resources/polaris-log4j.xml
+++ b/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-2021-plugin/src/main/resources/polaris-log4j.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+    <appender name="POLARIS_LOG_FILE" class="org.apache.log4j.RollingFileAppender">
+        <param name="File" value="${polaris.log.home}/polaris.log"/>
+        <param name="Append" value="true"/>
+        <param name="MaxBackupIndex" value="10"/>
+        <param name="MaxFileSize" value="10MB"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern"
+                    value="[%d{yyyy-MM-dd HH:mm:ss:SSS}] [%-5p] [method:%l]%n%m%n%n"/>
+        </layout>
+    </appender>
+    <appender name="POLARIS_UPDATE_EVENT_LOG_FILE" class="org.apache.log4j.RollingFileAppender">
+        <param name="File" value="${polaris.log.home}/polaris-update-event.log"/>
+        <param name="Append" value="true"/>
+        <param name="MaxBackupIndex" value="10"/>
+        <param name="MaxFileSize" value="10MB"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern"
+                    value="[%d{yyyy-MM-dd HH:mm:ss:SSS}] [%-5p] [method:%l]%n%m%n%n"/>
+        </layout>
+    </appender>
+    <appender name="POLARIS_UPDATE_EVENT_LOG_FILE_ASYNC" class="org.apache.log4j.AsyncAppender">
+        <param name="BufferSize" value="512"/>
+        <param name="Blocking" value="false"/>
+        <appender-ref ref="POLARIS_UPDATE_EVENT_LOG_FILE"/>
+    </appender>
+    <appender name="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"
+            class="org.apache.log4j.RollingFileAppender">
+        <param name="File" value="${polaris.log.home}/polaris-circuitbreaker.log"/>
+        <param name="Append" value="true"/>
+        <param name="MaxBackupIndex" value="10"/>
+        <param name="MaxFileSize" value="10MB"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern"
+                    value="[%d{yyyy-MM-dd HH:mm:ss:SSS}] [%-5p] [method:%l]%n%m%n%n"/>
+        </layout>
+    </appender>
+    <appender name="POLARIS_HEALTH_CHECK_EVENT_LOG_FILE"
+            class="org.apache.log4j.RollingFileAppender">
+        <param name="File" value="${polaris.log.home}/polaris-healthcheck-event.log"/>
+        <param name="Append" value="true"/>
+        <param name="MaxBackupIndex" value="10"/>
+        <param name="MaxFileSize" value="10MB"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern"
+                    value="[%d{yyyy-MM-dd HH:mm:ss:SSS}] [%-5p] [method:%l]%n%m%n%n"/>
+        </layout>
+    </appender>
+    <appender name="POLARIS_LOSSLESS_EVENT_LOG_FILE"
+              class="org.apache.log4j.RollingFileAppender">
+        <param name="File" value="${polaris.log.home}/polaris-lossless-event.log"/>
+        <param name="Append" value="true"/>
+        <param name="MaxBackupIndex" value="10"/>
+        <param name="MaxFileSize" value="10MB"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern"
+                   value="%m|[%d{yyyy-MM-dd HH:mm:ss:SSS}]%n"/>
+        </layout>
+    </appender>
+    <appender name="POLARIS_INSTANCE_HEARTBEAT_LOG_FILE"
+              class="org.apache.log4j.RollingFileAppender">
+        <param name="File" value="${polaris.log.home}/polaris-instance-heartbeat.log"/>
+        <param name="Append" value="true"/>
+        <param name="MaxBackupIndex" value="10"/>
+        <param name="MaxFileSize" value="10MB"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern"
+                   value="%m|[%d{yyyy-MM-dd HH:mm:ss:SSS}]%n"/>
+        </layout>
+    </appender>
+
+    <logger name="com.tencent.polaris" additivity="false">
+        <level value="INFO"/>
+        <appender-ref ref="POLARIS_LOG_FILE"/>
+    </logger>
+    <logger name="polaris-update-event" additivity="false">
+        <level value="INFO"/>
+        <appender-ref ref="POLARIS_UPDATE_EVENT_LOG_FILE"/>
+    </logger>
+    <logger name="polaris-update-event-async" additivity="false">
+        <level value="INFO"/>
+        <appender-ref ref="POLARIS_UPDATE_EVENT_LOG_FILE_ASYNC"/>
+    </logger>
+    <logger name="polaris-circuitbreaker" additivity="false">
+        <level value="INFO"/>
+        <appender-ref ref="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"/>
+    </logger>
+    <logger name="polaris-healthcheck-event" additivity="false">
+        <level value="INFO"/>
+        <appender-ref ref="POLARIS_HEALTH_CHECK_EVENT_LOG_FILE"/>
+    </logger>
+    <logger name="polaris-lossless-event" additivity="false">
+        <level value="INFO"/>
+        <appender-ref ref="POLARIS_LOSSLESS_EVENT_LOG_FILE"/>
+    </logger>
+    <logger name="polaris-instance-heartbeat" additivity="false">
+        <level value="INFO"/>
+        <appender-ref ref="POLARIS_INSTANCE_HEARTBEAT_LOG_FILE"/>
+    </logger>
+</log4j:configuration>

--- a/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-2021-plugin/src/main/resources/polaris-log4j2.xml
+++ b/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-2021-plugin/src/main/resources/polaris-log4j2.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+        <RollingFile name="POLARIS_LOG_FILE" fileName="${sys:polaris.log.home}/polaris.log"
+                filePattern="${sys:polaris.log.home}/polaris.log.%d{yyyy-MM-dd}.%i">
+            <PatternLayout>
+                <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %p [%-5t:%c{2}] %m%n</Pattern>
+            </PatternLayout>
+
+            <Policies>
+                <TimeBasedTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="${sys:polaris.log.file.size:-10MB}"/>
+            </Policies>
+
+            <DefaultRolloverStrategy max="${sys:polaris.log.retain.count:-7}"/>
+        </RollingFile>
+
+        <RollingFile name="POLARIS_UPDATE_EVENT_LOG_FILE"
+                fileName="${sys:polaris.log.home}/polaris-update-event.log"
+                filePattern="${sys:polaris.log.home}/polaris-update-event.log.%d{yyyy-MM-dd}.%i">
+            <PatternLayout>
+                <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %p [%-5t:%c{2}] %m%n</Pattern>
+            </PatternLayout>
+
+            <Policies>
+                <TimeBasedTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="${sys:polaris.update.event.log.file.size:-10MB}"/>
+            </Policies>
+
+            <DefaultRolloverStrategy max="${sys:polaris.update.event.log.retain.count:-7}"/>
+        </RollingFile>
+
+        <RollingFile name="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"
+                fileName="${sys:polaris.log.home}/polaris-circuitbreaker.log"
+                filePattern="${sys:polaris.log.home}/polaris-circuitbreaker.log.%d{yyyy-MM-dd}.%i">
+            <PatternLayout>
+                <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %p [%-5t:%c{2}] %m%n</Pattern>
+            </PatternLayout>
+
+            <Policies>
+                <TimeBasedTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy
+                        size="${sys:polaris.circuitbreaker.event.log.file.size:-10MB}"/>
+            </Policies>
+
+            <DefaultRolloverStrategy max="${sys:polaris.circuitbreaker.event.log.retain.count:-7}"/>
+        </RollingFile>
+
+        <RollingFile name="POLARIS_HEALTH_CHECK_EVENT_LOG_FILE"
+                fileName="${sys:polaris.log.home}/polaris-healthcheck-event"
+                filePattern="${sys:polaris.log.home}/polaris-healthcheck-event.log.%d{yyyy-MM-dd}.%i">
+            <PatternLayout>
+                <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %p [%-5t:%c{2}] %m%n</Pattern>
+            </PatternLayout>
+
+            <Policies>
+                <TimeBasedTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy
+                        size="${sys:polaris.healthcheck.event.log.file.size:-10MB}"/>
+            </Policies>
+
+            <DefaultRolloverStrategy max="${sys:polaris.healthcheck.event.log.retain.count:-7}"/>
+        </RollingFile>
+
+        <RollingFile name="POLARIS_LOSSLESS_EVENT_LOG_FILE"
+                     fileName="${sys:polaris.log.home}/polaris-lossless-event"
+                     filePattern="${sys:polaris.log.home}/polaris-lossless-event.log.%d{yyyy-MM-dd}.%i">
+            <PatternLayout>
+                <Pattern>%m|%d{yyyy-MM-dd HH:mm:ss.SSS}%n</Pattern>
+            </PatternLayout>
+
+            <Policies>
+                <TimeBasedTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy
+                        size="${sys:polaris.lossless.event.log.file.size:-10MB}"/>
+            </Policies>
+
+            <DefaultRolloverStrategy max="${sys:polaris.lossless.event.log.retain.count:-7}"/>
+        </RollingFile>
+
+        <RollingFile name="POLARIS_INSTANCE_HEARTBEAT_LOG_FILE"
+                     fileName="${sys:polaris.log.home}/polaris-instance-heartbeat"
+                     filePattern="${sys:polaris.log.home}/polaris-instance-heartbeat.log.%d{yyyy-MM-dd}.%i">
+            <PatternLayout>
+                <Pattern>%m|%d{yyyy-MM-dd HH:mm:ss.SSS}%n</Pattern>
+            </PatternLayout>
+
+            <Policies>
+                <TimeBasedTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy
+                        size="${sys:polaris.instance.heartbeat.log.file.size:-10MB}"/>
+            </Policies>
+
+            <DefaultRolloverStrategy max="${sys:polaris.instance.heartbeat.log.retain.count:-7}"/>
+        </RollingFile>
+    </Appenders>
+
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+        <Logger name="com.tencent.polaris"
+                level="${sys:polaris.log.level:-info}"
+                additivity="false">
+            <AppenderRef ref="POLARIS_LOG_FILE"/>
+        </Logger>
+        <Logger name="polaris-update-event-async"
+                level="${sys:polaris.update.event.log.level:-info}"
+                additivity="false">
+            <AppenderRef ref="POLARIS_UPDATE_EVENT_LOG_FILE"/>
+        </Logger>
+        <Logger name="polaris-circuitbreaker"
+                level="${sys:polaris.circuitbreaker.event.log.level:-info}"
+                additivity="false">
+            <AppenderRef ref="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"/>
+        </Logger>
+        <Logger name="polaris-healthcheck-event"
+                level="${sys:polaris.healthcheck.event.log.level:-info}"
+                additivity="false">
+            <AppenderRef ref="POLARIS_HEALTH_CHECK_EVENT_LOG_FILE"/>
+        </Logger>
+        <!--        <AsyncLogger name="polaris-update-event-async"-->
+        <!--                level="${sys:polaris-update-event.log.level:-info}"-->
+        <!--                additivity="false">-->
+        <!--            <AppenderRef ref="POLARIS_UPDATE_EVENT_LOG_FILE"/>-->
+        <!--        </AsyncLogger>-->
+        <Logger name="polaris-lossless-event"
+                level="${sys:polaris.lossless.event.log.level:-info}"
+                additivity="false">
+            <AppenderRef ref="POLARIS_LOSSLESS_EVENT_LOG_FILE"/>
+        </Logger>
+        <Logger name="polaris-instance-heartbeat"
+                level="${sys:polaris.instance.heartbeat.log.level:-info}"
+                additivity="false">
+            <AppenderRef ref="POLARIS_INSTANCE_HEARTBEAT_LOG_FILE"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-2021-plugin/src/main/resources/polaris-logback.xml
+++ b/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-2021-plugin/src/main/resources/polaris-logback.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration debug="false" scan="true" scanPeriod="30 seconds" packagingData="true">
+    <contextName>polaris</contextName>
+
+
+    <appender name="POLARIS_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${polaris.log.home}/polaris.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>${polaris.log.home}/polaris.log.%i</fileNamePattern>
+            <maxIndex>${polaris.log.retain.count:-7}</maxIndex>
+        </rollingPolicy>
+
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>${polaris.log.file.size:-10MB}</maxFileSize>
+        </triggeringPolicy>
+
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %p [%-5t:%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="POLARIS_UPDATE_EVENT_LOG_FILE"
+            class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${polaris.log.home}/polaris-update-event.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>${polaris.log.home}/polaris-update-event.log.%i</fileNamePattern>
+            <maxIndex>${polaris.update.event.log.retain.count:-7}</maxIndex>
+        </rollingPolicy>
+
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>${polaris.update.event.log.file.size:-10MB}</maxFileSize>
+        </triggeringPolicy>
+
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %p [%-5t:%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"
+            class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${polaris.log.home}/polaris-circuitbreaker.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>${polaris.log.home}/polaris-circuitbreaker.log.%i
+            </fileNamePattern>
+            <maxIndex>${polaris.circuitbreaker.event.log.retain.count:-7}</maxIndex>
+        </rollingPolicy>
+
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>${polaris.circuitbreaker.event.log.file.size:-10MB}</maxFileSize>
+        </triggeringPolicy>
+
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %p [%-5t:%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="POLARIS_HEALTH_CHECK_EVENT_LOG_FILE"
+            class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${polaris.log.home}/polaris-healthcheck-event.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>${polaris.log.home}/polaris-healthcheck-event.log.%i
+            </fileNamePattern>
+            <maxIndex>${polaris.healthcheck.event.log.retain.count:-7}</maxIndex>
+        </rollingPolicy>
+
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>${polaris.healthcheck.event.log.file.size:-10MB}</maxFileSize>
+        </triggeringPolicy>
+
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %p [%-5t:%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="POLARIS_LOSSLESS_EVENT_LOG_FILE"
+              class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${polaris.log.home}/polaris-lossless-event.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>${polaris.log.home}/polaris-lossless-event.log.%i
+            </fileNamePattern>
+            <maxIndex>${polaris.lossless.event.log.retain.count:-7}</maxIndex>
+        </rollingPolicy>
+
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>${polaris.lossless.event.log.file.size:-10MB}</maxFileSize>
+        </triggeringPolicy>
+
+        <encoder>
+            <pattern>%m|%d{yyyy-MM-dd HH:mm:ss.SSS}%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="POLARIS_INSTANCE_HEARTBEAT_LOG_FILE"
+              class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${polaris.log.home}/polaris-instance-heartbeat.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>${polaris.log.home}/polaris-instance-heartbeat.log.%i
+            </fileNamePattern>
+            <maxIndex>${polaris.instance.heartbeat.log.retain.count:-7}</maxIndex>
+        </rollingPolicy>
+
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>${polaris.instance.heartbeat.log.file.size:-10MB}</maxFileSize>
+        </triggeringPolicy>
+
+        <encoder>
+            <pattern>%m|%d{yyyy-MM-dd HH:mm:ss.SSS}%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="POLARIS_UPDATE_EVENT_LOG_FILE_ASYNC"
+            class="ch.qos.logback.classic.AsyncAppender">
+        <discardingThreshold>0</discardingThreshold>
+        <queueSize>512</queueSize>
+        <appender-ref ref="POLARIS_UPDATE_EVENT_LOG_FILE"/>
+    </appender>
+
+    <logger name="com.tencent.polaris" level="${polaris.log.level:-info}"
+            additivity="false">
+        <appender-ref ref="POLARIS_LOG_FILE"/>
+    </logger>
+
+    <logger name="polaris-update-event" level="${polaris.update.event.log.level:-info}"
+            additivity="false">
+        <appender-ref ref="POLARIS_UPDATE_EVENT_LOG_FILE"/>
+    </logger>
+
+    <logger name="polaris-update-event-async" level="${polaris.update.event.log.level:-info}"
+            additivity="false">
+        <appender-ref ref="POLARIS_UPDATE_EVENT_LOG_FILE_ASYNC"/>
+    </logger>
+
+    <logger name="polaris-circuitbreaker"
+            level="${polaris.circuitbreaker.event.log.level:-info}"
+            additivity="false">
+        <appender-ref ref="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"/>
+    </logger>
+
+    <logger name="polaris-healthcheck-event"
+            level="${polaris.healthcheck.event.log.level:-info}"
+            additivity="false">
+        <appender-ref ref="POLARIS_HEALTH_CHECK_EVENT_LOG_FILE"/>
+    </logger>
+
+    <logger name="polaris-lossless-event"
+            level="${polaris.lossless.event.log.level:-info}"
+            additivity="false">
+        <appender-ref ref="POLARIS_LOSSLESS_EVENT_LOG_FILE"/>
+    </logger>
+
+    <logger name="polaris-instance-heartbeat"
+            level="${polaris.instance.heartbeat.log.level:-info}"
+            additivity="false">
+        <appender-ref ref="POLARIS_INSTANCE_HEARTBEAT_LOG_FILE"/>
+    </logger>
+</configuration>

--- a/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-2022-plugin/src/main/resources/polaris-log4j.xml
+++ b/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-2022-plugin/src/main/resources/polaris-log4j.xml
@@ -29,7 +29,7 @@
     </appender>
     <appender name="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"
             class="org.apache.log4j.RollingFileAppender">
-        <param name="File" value="${polaris.log.home}/polaris-circuitbreaker-event.log"/>
+        <param name="File" value="${polaris.log.home}/polaris-circuitbreaker.log"/>
         <param name="Append" value="true"/>
         <param name="MaxBackupIndex" value="10"/>
         <param name="MaxFileSize" value="10MB"/>
@@ -84,7 +84,7 @@
         <level value="INFO"/>
         <appender-ref ref="POLARIS_UPDATE_EVENT_LOG_FILE_ASYNC"/>
     </logger>
-    <logger name="polaris-circuitbreaker-event" additivity="false">
+    <logger name="polaris-circuitbreaker" additivity="false">
         <level value="INFO"/>
         <appender-ref ref="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"/>
     </logger>

--- a/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-2022-plugin/src/main/resources/polaris-log4j2.xml
+++ b/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-2022-plugin/src/main/resources/polaris-log4j2.xml
@@ -35,8 +35,8 @@
         </RollingFile>
 
         <RollingFile name="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"
-                fileName="${sys:polaris.log.home}/polaris-circuitbreaker-event.log"
-                filePattern="${sys:polaris.log.home}/polaris-circuitbreaker-event.log.%d{yyyy-MM-dd}.%i">
+                fileName="${sys:polaris.log.home}/polaris-circuitbreaker.log"
+                filePattern="${sys:polaris.log.home}/polaris-circuitbreaker.log.%d{yyyy-MM-dd}.%i">
             <PatternLayout>
                 <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %p [%-5t:%c{2}] %m%n</Pattern>
             </PatternLayout>
@@ -113,7 +113,7 @@
                 additivity="false">
             <AppenderRef ref="POLARIS_UPDATE_EVENT_LOG_FILE"/>
         </Logger>
-        <Logger name="polaris-circuitbreaker-event"
+        <Logger name="polaris-circuitbreaker"
                 level="${sys:polaris.circuitbreaker.event.log.level:-info}"
                 additivity="false">
             <AppenderRef ref="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"/>

--- a/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-2022-plugin/src/main/resources/polaris-logback.xml
+++ b/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-2022-plugin/src/main/resources/polaris-logback.xml
@@ -41,10 +41,10 @@
 
     <appender name="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"
             class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${polaris.log.home}/polaris-circuitbreaker-event.log</file>
+        <file>${polaris.log.home}/polaris-circuitbreaker.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>${polaris.log.home}/polaris-circuitbreaker-event.log.%i
+            <fileNamePattern>${polaris.log.home}/polaris-circuitbreaker.log.%i
             </fileNamePattern>
             <maxIndex>${polaris.circuitbreaker.event.log.retain.count:-7}</maxIndex>
         </rollingPolicy>
@@ -137,7 +137,7 @@
         <appender-ref ref="POLARIS_UPDATE_EVENT_LOG_FILE_ASYNC"/>
     </logger>
 
-    <logger name="polaris-circuitbreaker-event"
+    <logger name="polaris-circuitbreaker"
             level="${polaris.circuitbreaker.event.log.level:-info}"
             additivity="false">
         <appender-ref ref="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"/>

--- a/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-2023-plugin/src/main/resources/polaris-log4j.xml
+++ b/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-2023-plugin/src/main/resources/polaris-log4j.xml
@@ -29,7 +29,7 @@
     </appender>
     <appender name="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"
             class="org.apache.log4j.RollingFileAppender">
-        <param name="File" value="${polaris.log.home}/polaris-circuitbreaker-event.log"/>
+        <param name="File" value="${polaris.log.home}/polaris-circuitbreaker.log"/>
         <param name="Append" value="true"/>
         <param name="MaxBackupIndex" value="10"/>
         <param name="MaxFileSize" value="10MB"/>
@@ -84,7 +84,7 @@
         <level value="INFO"/>
         <appender-ref ref="POLARIS_UPDATE_EVENT_LOG_FILE_ASYNC"/>
     </logger>
-    <logger name="polaris-circuitbreaker-event" additivity="false">
+    <logger name="polaris-circuitbreaker" additivity="false">
         <level value="INFO"/>
         <appender-ref ref="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"/>
     </logger>

--- a/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-2023-plugin/src/main/resources/polaris-log4j2.xml
+++ b/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-2023-plugin/src/main/resources/polaris-log4j2.xml
@@ -35,8 +35,8 @@
         </RollingFile>
 
         <RollingFile name="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"
-                fileName="${sys:polaris.log.home}/polaris-circuitbreaker-event.log"
-                filePattern="${sys:polaris.log.home}/polaris-circuitbreaker-event.log.%d{yyyy-MM-dd}.%i">
+                fileName="${sys:polaris.log.home}/polaris-circuitbreaker.log"
+                filePattern="${sys:polaris.log.home}/polaris-circuitbreaker.log.%d{yyyy-MM-dd}.%i">
             <PatternLayout>
                 <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %p [%-5t:%c{2}] %m%n</Pattern>
             </PatternLayout>
@@ -113,7 +113,7 @@
                 additivity="false">
             <AppenderRef ref="POLARIS_UPDATE_EVENT_LOG_FILE"/>
         </Logger>
-        <Logger name="polaris-circuitbreaker-event"
+        <Logger name="polaris-circuitbreaker"
                 level="${sys:polaris.circuitbreaker.event.log.level:-info}"
                 additivity="false">
             <AppenderRef ref="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"/>

--- a/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-2023-plugin/src/main/resources/polaris-logback.xml
+++ b/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-2023-plugin/src/main/resources/polaris-logback.xml
@@ -41,10 +41,10 @@
 
     <appender name="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"
             class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${polaris.log.home}/polaris-circuitbreaker-event.log</file>
+        <file>${polaris.log.home}/polaris-circuitbreaker.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>${polaris.log.home}/polaris-circuitbreaker-event.log.%i
+            <fileNamePattern>${polaris.log.home}/polaris-circuitbreaker.log.%i
             </fileNamePattern>
             <maxIndex>${polaris.circuitbreaker.event.log.retain.count:-7}</maxIndex>
         </rollingPolicy>
@@ -137,7 +137,7 @@
         <appender-ref ref="POLARIS_UPDATE_EVENT_LOG_FILE_ASYNC"/>
     </logger>
 
-    <logger name="polaris-circuitbreaker-event"
+    <logger name="polaris-circuitbreaker"
             level="${polaris.circuitbreaker.event.log.level:-info}"
             additivity="false">
         <appender-ref ref="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"/>

--- a/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-hoxton-plugin/src/main/resources/polaris-log4j.xml
+++ b/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-hoxton-plugin/src/main/resources/polaris-log4j.xml
@@ -29,7 +29,7 @@
     </appender>
     <appender name="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"
             class="org.apache.log4j.RollingFileAppender">
-        <param name="File" value="${polaris.log.home}/polaris-circuitbreaker-event.log"/>
+        <param name="File" value="${polaris.log.home}/polaris-circuitbreaker.log"/>
         <param name="Append" value="true"/>
         <param name="MaxBackupIndex" value="10"/>
         <param name="MaxFileSize" value="10MB"/>
@@ -84,7 +84,7 @@
         <level value="INFO"/>
         <appender-ref ref="POLARIS_UPDATE_EVENT_LOG_FILE_ASYNC"/>
     </logger>
-    <logger name="polaris-circuitbreaker-event" additivity="false">
+    <logger name="polaris-circuitbreaker" additivity="false">
         <level value="INFO"/>
         <appender-ref ref="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"/>
     </logger>

--- a/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-hoxton-plugin/src/main/resources/polaris-log4j2.xml
+++ b/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-hoxton-plugin/src/main/resources/polaris-log4j2.xml
@@ -35,8 +35,8 @@
         </RollingFile>
 
         <RollingFile name="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"
-                fileName="${sys:polaris.log.home}/polaris-circuitbreaker-event.log"
-                filePattern="${sys:polaris.log.home}/polaris-circuitbreaker-event.log.%d{yyyy-MM-dd}.%i">
+                fileName="${sys:polaris.log.home}/polaris-circuitbreaker.log"
+                filePattern="${sys:polaris.log.home}/polaris-circuitbreaker.log.%d{yyyy-MM-dd}.%i">
             <PatternLayout>
                 <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %p [%-5t:%c{2}] %m%n</Pattern>
             </PatternLayout>
@@ -113,7 +113,7 @@
                 additivity="false">
             <AppenderRef ref="POLARIS_UPDATE_EVENT_LOG_FILE"/>
         </Logger>
-        <Logger name="polaris-circuitbreaker-event"
+        <Logger name="polaris-circuitbreaker"
                 level="${sys:polaris.circuitbreaker.event.log.level:-info}"
                 additivity="false">
             <AppenderRef ref="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"/>

--- a/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-hoxton-plugin/src/main/resources/polaris-logback.xml
+++ b/polaris-agent-plugins/spring-cloud-plugins/spring-cloud-hoxton-plugin/src/main/resources/polaris-logback.xml
@@ -41,10 +41,10 @@
 
     <appender name="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"
             class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${polaris.log.home}/polaris-circuitbreaker-event.log</file>
+        <file>${polaris.log.home}/polaris-circuitbreaker.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>${polaris.log.home}/polaris-circuitbreaker-event.log.%i
+            <fileNamePattern>${polaris.log.home}/polaris-circuitbreaker.log.%i
             </fileNamePattern>
             <maxIndex>${polaris.circuitbreaker.event.log.retain.count:-7}</maxIndex>
         </rollingPolicy>
@@ -137,7 +137,7 @@
         <appender-ref ref="POLARIS_UPDATE_EVENT_LOG_FILE_ASYNC"/>
     </logger>
 
-    <logger name="polaris-circuitbreaker-event"
+    <logger name="polaris-circuitbreaker"
             level="${polaris.circuitbreaker.event.log.level:-info}"
             additivity="false">
         <appender-ref ref="POLARIS_CIRCUIT_BREAKER_EVENT_LOG_FILE"/>


### PR DESCRIPTION
Fixes #
polaris-java-agent中配置文件有误，circuitbreaker日志应通过名为"polaris-circuitbreaker"的logger记录，而不是"polaris-circuitbreaker-event"。

- [ ] Docs
- [ ] Discovery
- [ ] Route
- [ ] RateLimit
- [x] CircuitBreaker
- [ ] Test and Release

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.
