### PR TITLE
fix: avoid metadata autoconfig and add spring-boot & dubbo example

### DIFF
--- a/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/dubbo-example-consumer/Dockerfile
+++ b/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/dubbo-example-consumer/Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine:3.19.1
+
+ARG file_name
+ARG java_version
+
+COPY ./target/${file_name} /app/main.jar
+
+WORKDIR /app
+
+RUN sed -i 's!https\?://dl-cdn.alpinelinux.org/!https://mirrors.tencent.com/!g' /etc/apk/repositories
+
+RUN set -eux && \
+    apk add openjdk${java_version} && \
+    apk add bind-tools && \
+    apk add busybox-extras && \
+    apk add findutils && \
+    apk add tcpdump && \
+    apk add tzdata && \
+    apk add curl && \
+    apk add bash && \
+    cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
+    echo "Asia/Shanghai" > /etc/timezone && \
+    date
+
+RUN chmod 777 /app/
+
+RUN ls -la /app/
+
+ENTRYPOINT ["java", "-jar", "/app/main.jar"]

--- a/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/dubbo-example-provider/Dockerfile
+++ b/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/dubbo-example-provider/Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine:3.19.1
+
+ARG file_name
+ARG java_version
+
+COPY ./target/${file_name} /app/main.jar
+
+WORKDIR /app
+
+RUN sed -i 's!https\?://dl-cdn.alpinelinux.org/!https://mirrors.tencent.com/!g' /etc/apk/repositories
+
+RUN set -eux && \
+    apk add openjdk${java_version} && \
+    apk add bind-tools && \
+    apk add busybox-extras && \
+    apk add findutils && \
+    apk add tcpdump && \
+    apk add tzdata && \
+    apk add curl && \
+    apk add bash && \
+    cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
+    echo "Asia/Shanghai" > /etc/timezone && \
+    date
+
+RUN chmod 777 /app/
+
+RUN ls -la /app/
+
+ENTRYPOINT ["java", "-jar", "/app/main.jar"]

--- a/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/pom.xml
+++ b/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/pom.xml
@@ -16,6 +16,7 @@
         <module>dubbo-example-provider</module>
         <module>dubbo-example-consumer</module>
         <module>spring-cloud-dubbo-examples</module>
+        <module>spring-boot-dubbo-example</module>
     </modules>
     <properties>
         <apache.dubbo.version>2.7.23</apache.dubbo.version>

--- a/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-boot-dubbo-example/pom.xml
+++ b/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-boot-dubbo-example/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>dubbo-2.7.x-examples</artifactId>
+        <groupId>com.tencent.polaris</groupId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>spring-boot-dubbo-example</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>sb-dubbo-provider</module>
+        <module>sb-dubbo-consumer</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>2.7.18</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-boot-dubbo-example/sb-dubbo-consumer/Dockerfile
+++ b/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-boot-dubbo-example/sb-dubbo-consumer/Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine:3.19.1
+
+ARG file_name
+ARG java_version
+
+COPY ./target/${file_name} /app/main.jar
+
+WORKDIR /app
+
+RUN sed -i 's!https\?://dl-cdn.alpinelinux.org/!https://mirrors.tencent.com/!g' /etc/apk/repositories
+
+RUN set -eux && \
+    apk add openjdk${java_version} && \
+    apk add bind-tools && \
+    apk add busybox-extras && \
+    apk add findutils && \
+    apk add tcpdump && \
+    apk add tzdata && \
+    apk add curl && \
+    apk add bash && \
+    cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
+    echo "Asia/Shanghai" > /etc/timezone && \
+    date
+
+RUN chmod 777 /app/
+
+RUN ls -la /app/
+
+ENTRYPOINT ["java", "-jar", "/app/main.jar"]

--- a/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-boot-dubbo-example/sb-dubbo-consumer/pom.xml
+++ b/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-boot-dubbo-example/sb-dubbo-consumer/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>spring-boot-dubbo-example</artifactId>
+        <groupId>com.tencent.polaris</groupId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.tencent.polaris</groupId>
+    <artifactId>sb-dubbo-consumer</artifactId>
+    <packaging>jar</packaging>
+    <name>sb-dubbo-consumer</name>
+    <description>Spring Boot + Dubbo 2.7 Consumer</description>
+
+    <dependencies>
+        <!-- Spring Boot Web -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <!-- Dubbo -->
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-registry-nacos</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-configcenter-nacos</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-registry-zookeeper</artifactId>
+            <!-- Dubbo 2.7.23 同时依赖了 dubbo-remoting-zookeeper(Curator 4) 和
+                 dubbo-remoting-zookeeper-curator5(Curator 5)，两套 Curator 同时进入 classpath
+                 会导致 java.lang.ClassNotFoundException: org.apache.curator.framework.listen.ListenerContainer
+                 这里排除 curator5 适配模块，统一走 Curator 4。 -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.dubbo</groupId>
+                    <artifactId>dubbo-remoting-zookeeper-curator5</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-configcenter-zookeeper</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.dubbo</groupId>
+                    <artifactId>dubbo-remoting-zookeeper-curator5</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Dubbo 服务接口 -->
+        <dependency>
+            <groupId>com.tencent.polaris</groupId>
+            <artifactId>dubbo-agent-example-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.7.18</version>
+                <configuration>
+                    <executable>true</executable>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-boot-dubbo-example/sb-dubbo-consumer/src/main/java/cn/polarismesh/agent/examples/dubbo/sb/consumer/DubboConsumerApplication.java
+++ b/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-boot-dubbo-example/sb-dubbo-consumer/src/main/java/cn/polarismesh/agent/examples/dubbo/sb/consumer/DubboConsumerApplication.java
@@ -1,0 +1,139 @@
+/*
+ * Tencent is pleased to support the open source community by making polaris-java-agent available.
+ *
+ * Copyright (C) 2021 Tencent. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cn.polarismesh.agent.examples.dubbo.sb.consumer;
+
+import cn.polarismesh.agent.examples.dubbo.api.EchoService;
+import cn.polarismesh.agent.examples.dubbo.api.GreetingService;
+import org.apache.dubbo.common.config.ConfigurationUtils;
+import org.apache.dubbo.common.constants.CommonConstants;
+import org.apache.dubbo.config.annotation.DubboReference;
+import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
+import org.apache.dubbo.rpc.RpcContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Spring Boot + Dubbo 2.7 Consumer 启动类.
+ */
+@SpringBootApplication
+@EnableDubbo
+public class DubboConsumerApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(DubboConsumerApplication.class, args);
+    }
+
+    /**
+     * Dubbo 服务消费者，封装 Dubbo RPC 调用.
+     */
+    @Component
+    public static class DubboServiceConsumer {
+
+        @DubboReference
+        private GreetingService greetingService;
+
+        @DubboReference(version = "1.0.0", providedBy = "sb-dubbo-provider")
+        private EchoService echoService;
+
+        /**
+         * 调用 sayHello，支持标签路由.
+         */
+        public String sayHello(String name) {
+            String tagValue = ConfigurationUtils.getProperty(CommonConstants.TAG_KEY);
+            if (tagValue != null) {
+                RpcContext.getContext().setAttachment(CommonConstants.TAG_KEY, tagValue);
+            }
+            return greetingService.sayHello(name);
+        }
+
+        /**
+         * 调用 sayHi，支持标签路由.
+         */
+        public String sayHi(String name) {
+            String tagValue = ConfigurationUtils.getProperty(CommonConstants.TAG_KEY);
+            if (tagValue != null) {
+                RpcContext.getContext().setAttachment(CommonConstants.TAG_KEY, tagValue);
+            }
+            return greetingService.sayHi(name);
+        }
+
+        /**
+         * 调用 echo，支持标签路由.
+         */
+        public String echo(String message) {
+            String tagValue = ConfigurationUtils.getProperty(CommonConstants.TAG_KEY);
+            if (tagValue != null) {
+                RpcContext.getContext().setAttachment(CommonConstants.TAG_KEY, tagValue);
+            }
+            return echoService.echo(message);
+        }
+    }
+
+    /**
+     * REST Controller，暴露 HTTP 端点调用 Dubbo 服务.
+     */
+    @RestController
+    public static class ConsumerController {
+
+        private static final Logger LOG =
+                LoggerFactory.getLogger(ConsumerController.class);
+
+        @Autowired
+        private DubboServiceConsumer dubboConsumer;
+
+        /**
+         * 通过 Dubbo RPC 调用 GreetingService.sayHello.
+         */
+        @GetMapping("/dubbo/sayHello")
+        public String dubboSayHello(
+                @RequestParam(defaultValue = "polaris") String name) {
+            String result = dubboConsumer.sayHello(name);
+            LOG.info("Dubbo sayHello: {}", result);
+            return result;
+        }
+
+        /**
+         * 通过 Dubbo RPC 调用 GreetingService.sayHi.
+         */
+        @GetMapping("/dubbo/sayHi")
+        public String dubboSayHi(
+                @RequestParam(defaultValue = "polaris") String name) {
+            String result = dubboConsumer.sayHi(name);
+            LOG.info("Dubbo sayHi: {}", result);
+            return result;
+        }
+
+        /**
+         * 通过 Dubbo RPC 调用 EchoService.echo.
+         */
+        @GetMapping("/dubbo/echo")
+        public String dubboEcho(
+                @RequestParam(defaultValue = "test") String message) {
+            String result = dubboConsumer.echo(message);
+            LOG.info("Dubbo echo: {}", result);
+            return result;
+        }
+    }
+}

--- a/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-boot-dubbo-example/sb-dubbo-consumer/src/main/resources/application.properties
+++ b/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-boot-dubbo-example/sb-dubbo-consumer/src/main/resources/application.properties
@@ -1,0 +1,9 @@
+server.port=17082
+spring.application.name=sb-dubbo-consumer
+# Dubbo 配置
+dubbo.application.name=sb-dubbo-consumer
+dubbo.registry.address=zookeeper://127.0.0.1:2181
+dubbo.protocol.name=dubbo
+dubbo.protocol.port=30880
+dubbo.consumer.timeout=3000
+dubbo.application.qosEnable=false

--- a/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-boot-dubbo-example/sb-dubbo-provider/Dockerfile
+++ b/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-boot-dubbo-example/sb-dubbo-provider/Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine:3.19.1
+
+ARG file_name
+ARG java_version
+
+COPY ./target/${file_name} /app/main.jar
+
+WORKDIR /app
+
+RUN sed -i 's!https\?://dl-cdn.alpinelinux.org/!https://mirrors.tencent.com/!g' /etc/apk/repositories
+
+RUN set -eux && \
+    apk add openjdk${java_version} && \
+    apk add bind-tools && \
+    apk add busybox-extras && \
+    apk add findutils && \
+    apk add tcpdump && \
+    apk add tzdata && \
+    apk add curl && \
+    apk add bash && \
+    cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
+    echo "Asia/Shanghai" > /etc/timezone && \
+    date
+
+RUN chmod 777 /app/
+
+RUN ls -la /app/
+
+ENTRYPOINT ["java", "-jar", "/app/main.jar"]

--- a/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-boot-dubbo-example/sb-dubbo-provider/pom.xml
+++ b/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-boot-dubbo-example/sb-dubbo-provider/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>spring-boot-dubbo-example</artifactId>
+        <groupId>com.tencent.polaris</groupId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.tencent.polaris</groupId>
+    <artifactId>sb-dubbo-provider</artifactId>
+    <packaging>jar</packaging>
+    <name>sb-dubbo-provider</name>
+    <description>Spring Boot + Dubbo 2.7 Provider</description>
+
+    <dependencies>
+        <!-- Spring Boot Web -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <!-- Dubbo -->
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-registry-nacos</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-configcenter-nacos</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-registry-zookeeper</artifactId>
+            <!-- Dubbo 2.7.23 同时依赖了 dubbo-remoting-zookeeper(Curator 4) 和
+                 dubbo-remoting-zookeeper-curator5(Curator 5)，两套 Curator 同时进入 classpath
+                 会导致 java.lang.ClassNotFoundException: org.apache.curator.framework.listen.ListenerContainer
+                 这里排除 curator5 适配模块，统一走 Curator 4。 -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.dubbo</groupId>
+                    <artifactId>dubbo-remoting-zookeeper-curator5</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.dubbo</groupId>
+            <artifactId>dubbo-configcenter-zookeeper</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.dubbo</groupId>
+                    <artifactId>dubbo-remoting-zookeeper-curator5</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- Dubbo 服务接口 -->
+        <dependency>
+            <groupId>com.tencent.polaris</groupId>
+            <artifactId>dubbo-agent-example-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.7.18</version>
+                <configuration>
+                    <executable>true</executable>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-boot-dubbo-example/sb-dubbo-provider/src/main/java/cn/polarismesh/agent/examples/dubbo/sb/provider/DubboProviderApplication.java
+++ b/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-boot-dubbo-example/sb-dubbo-provider/src/main/java/cn/polarismesh/agent/examples/dubbo/sb/provider/DubboProviderApplication.java
@@ -1,0 +1,105 @@
+/*
+ * Tencent is pleased to support the open source community by making polaris-java-agent available.
+ *
+ * Copyright (C) 2021 Tencent. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package cn.polarismesh.agent.examples.dubbo.sb.provider;
+
+import static org.apache.dubbo.common.constants.CommonConstants.DUBBO_LABELS;
+
+import cn.polarismesh.agent.examples.dubbo.api.EchoService;
+import cn.polarismesh.agent.examples.dubbo.api.GreetingService;
+import org.apache.dubbo.common.config.ConfigurationUtils;
+import org.apache.dubbo.config.annotation.DubboService;
+import org.apache.dubbo.config.spring.context.annotation.EnableDubbo;
+import org.apache.dubbo.rpc.RpcContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Spring Boot + Dubbo 2.7 Provider 启动类.
+ */
+@SpringBootApplication
+@EnableDubbo
+public class DubboProviderApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(DubboProviderApplication.class, args);
+    }
+
+    /**
+     * REST Controller，暴露 HTTP 端点用于验证服务存活.
+     */
+    @RestController
+    public static class EchoController {
+        private static final Logger LOG = LoggerFactory.getLogger(EchoController.class);
+
+        @Value("${spring.application.name}")
+        private String appName;
+
+        @Value("${server.port:0}")
+        private int port;
+
+        @GetMapping("/echo/{string}")
+        public String echo(@PathVariable String string) {
+            String result = String.format("[REST] Hello %s, from %s:%d", string, appName, port);
+            LOG.info("echo called: {}", result);
+            return result;
+        }
+    }
+
+    /**
+     * Dubbo GreetingService 实现.
+     */
+    @DubboService
+    public static class GreetingServiceImpl implements GreetingService {
+
+        @Override
+        public String sayHello(String name) {
+            RpcContext ctx = RpcContext.getContext();
+            return "hello, " + name + " (provider host: " + ctx.getLocalHost()
+                    + ", port: " + ctx.getLocalPort() + ")";
+        }
+
+        @Override
+        public String sayHi(String name) {
+            String dubboLabel = ConfigurationUtils.getProperty(DUBBO_LABELS);
+            RpcContext ctx = RpcContext.getContext();
+            return "[provider by polaris] hi, " + name + " (labels: " + dubboLabel
+                    + ", provider host: " + ctx.getLocalHost()
+                    + ", port: " + ctx.getLocalPort() + ")";
+        }
+    }
+
+    /**
+     * Dubbo EchoService 实现.
+     */
+    @DubboService(version = "1.0.0")
+    public static class EchoServiceImpl implements EchoService {
+
+        @Override
+        public String echo(String message) {
+            RpcContext ctx = RpcContext.getContext();
+            return "echo: " + message + " (provider host: " + ctx.getLocalHost()
+                    + ", port: " + ctx.getLocalPort() + ")";
+        }
+    }
+}

--- a/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-boot-dubbo-example/sb-dubbo-provider/src/main/resources/application.properties
+++ b/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-boot-dubbo-example/sb-dubbo-provider/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+server.port=0
+spring.application.name=sb-dubbo-provider
+# Dubbo 配置
+dubbo.application.name=sb-dubbo-provider
+#dubbo.application.metadataType=local
+dubbo.registry.address=zookeeper://127.0.0.1:2181
+dubbo.registries.nacos.address=nacos://9.135.13.199:8848
+dubbo.protocol.name=dubbo
+dubbo.protocol.port=20880
+dubbo.application.qosEnable=false

--- a/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-cloud-dubbo-examples/sc-dubbo-consumer/Dockerfile
+++ b/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-cloud-dubbo-examples/sc-dubbo-consumer/Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine:3.19.1
+
+ARG file_name
+ARG java_version
+
+COPY ./target/${file_name} /app/main.jar
+
+WORKDIR /app
+
+RUN sed -i 's!https\?://dl-cdn.alpinelinux.org/!https://mirrors.tencent.com/!g' /etc/apk/repositories
+
+RUN set -eux && \
+    apk add openjdk${java_version} && \
+    apk add bind-tools && \
+    apk add busybox-extras && \
+    apk add findutils && \
+    apk add tcpdump && \
+    apk add tzdata && \
+    apk add curl && \
+    apk add bash && \
+    cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
+    echo "Asia/Shanghai" > /etc/timezone && \
+    date
+
+RUN chmod 777 /app/
+
+RUN ls -la /app/
+
+ENTRYPOINT ["java", "-jar", "/app/main.jar"]

--- a/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-cloud-dubbo-examples/sc-dubbo-provider/Dockerfile
+++ b/polaris-agent-examples/dubbo-plugins-examples/dubbo-2.7.x-examples/spring-cloud-dubbo-examples/sc-dubbo-provider/Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine:3.19.1
+
+ARG file_name
+ARG java_version
+
+COPY ./target/${file_name} /app/main.jar
+
+WORKDIR /app
+
+RUN sed -i 's!https\?://dl-cdn.alpinelinux.org/!https://mirrors.tencent.com/!g' /etc/apk/repositories
+
+RUN set -eux && \
+    apk add openjdk${java_version} && \
+    apk add bind-tools && \
+    apk add busybox-extras && \
+    apk add findutils && \
+    apk add tcpdump && \
+    apk add tzdata && \
+    apk add curl && \
+    apk add bash && \
+    cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
+    echo "Asia/Shanghai" > /etc/timezone && \
+    date
+
+RUN chmod 777 /app/
+
+RUN ls -la /app/
+
+ENTRYPOINT ["java", "-jar", "/app/main.jar"]

--- a/polaris-agent-plugins/dubbo-plugins/dubbo-2.7.x-plugin/src/main/java/cn/polarismesh/agent/plugin/dubbo27/constants/DubboConstants.java
+++ b/polaris-agent-plugins/dubbo-plugins/dubbo-2.7.x-plugin/src/main/java/cn/polarismesh/agent/plugin/dubbo27/constants/DubboConstants.java
@@ -62,4 +62,6 @@ public interface DubboConstants {
      */
     String AUTO_REGISTRY_ID_PREFIX_ZERO = "org.apache.dubbo.config.RegistryConfig#0";
 
+    String AUTO_CONFIG_CENTER_ID_PREFIX_ZERO = "org.apache.dubbo.config.spring.ConfigCenterBean#0";
+
 }

--- a/polaris-agent-plugins/dubbo-plugins/dubbo-2.7.x-plugin/src/main/java/cn/polarismesh/agent/plugin/dubbo27/interceptor/DubboBootstrapInterceptor.java
+++ b/polaris-agent-plugins/dubbo-plugins/dubbo-2.7.x-plugin/src/main/java/cn/polarismesh/agent/plugin/dubbo27/interceptor/DubboBootstrapInterceptor.java
@@ -26,24 +26,16 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Logger;
 
+import org.apache.dubbo.config.ApplicationConfig;
 import org.apache.dubbo.config.ConfigCenterConfig;
+import org.apache.dubbo.config.MetadataReportConfig;
 import org.apache.dubbo.config.RegistryConfig;
 import org.apache.dubbo.config.context.ConfigManager;
 import org.apache.dubbo.rpc.model.ApplicationModel;
 
-/**
- * DubboBootstrap.initialize() 拦截器，在初始化完成后替换注册中心为 Polaris.
- *
- * <p>在 DubboBootstrap.initialize() 的 after 阶段执行，确保在
- * {@code startConfigCenter()} 内部的 {@code configManager.refreshAll()}
- * 以及 {@code loadRemoteConfigs()} 全部完成后再替换，避免被 refresh 机制覆盖。
- * 通过 ConfigManager 获取所有 RegistryConfig，将非 polaris 协议的注册中心
- * 替换为 polaris 协议和地址，同时注入扩展参数。
- * Polaris 地址依次从 JVM 系统属性 {@code dubbo.registry.address}、
- * 本地配置文件、默认值 {@code polaris://127.0.0.1:8091} 读取.</p>
- */
 public class DubboBootstrapInterceptor implements Interceptor {
 
     private static final Logger LOGGER =
@@ -52,6 +44,18 @@ public class DubboBootstrapInterceptor implements Interceptor {
 
     @Override
     public void before(Object target, Object[] args) {
+        injectConfigCenter();
+        disableMetadataReport();
+
+    }
+
+    @Override
+    public void after(Object target, Object[] args,
+            Object result, Throwable throwable) {
+        modifyExistedRegistry();
+    }
+
+    public void injectConfigCenter() {
         // fail-safe 总入口: ASM 框架对 before() 不包 try/catch,
         // 此处任何抛出都会让 DubboBootstrap.initialize() 失败 → 应用启动失败,
         // 因此整段必须 try { ... } catch (Throwable) 兜底。
@@ -72,6 +76,7 @@ public class DubboBootstrapInterceptor implements Interceptor {
             Map<String, String> polarisParameters =
                     DubboConfigProvider.getConfigCenterParameters();
 
+            // 分支 0: 无任何 config-center → 新增 polaris
             if (centers == null || centers.isEmpty()) {
                 LOGGER.info("No ConfigCenter found, adding Polaris "
                         + "ConfigCenter at " + polarisAddress);
@@ -81,16 +86,20 @@ public class DubboBootstrapInterceptor implements Interceptor {
                 return;
             }
 
+            // 分支 1: 已有 polaris config-center → no-op
             for (ConfigCenterConfig cc : centers) {
                 if (DubboConstants.POLARIS_PROTOCOL.equals(cc.getProtocol())) {
-                    continue; // 已经是 polaris,不动
+                    LOGGER.info("Polaris ConfigCenter already present (id="
+                            + cc.getId() + ", address="
+                            + cc.getAddress()
+                            + "), agent skips config-center rewrite");
+                    return;
                 }
-                LOGGER.info("Replacing ConfigCenter ["
-                        + cc.getProtocol() + "://" + cc.getAddress()
-                        + "] -> [" + DubboConstants.POLARIS_PROTOCOL + "://"
-                        + polarisAddress + "]");
-                applyPolarisFields(cc, polarisAddress, polarisParameters);
             }
+
+            // 分支 2: 改写首位为 polaris,删除其余
+            rewriteFirstConfigCenterRemoveRest(configManager, centers,
+                    polarisAddress, polarisParameters);
         } catch (Throwable th) {
             LOGGER.warning("Polaris config-center rewrite failed; "
                     + "falling back to original config-center: "
@@ -98,34 +107,124 @@ public class DubboBootstrapInterceptor implements Interceptor {
         }
     }
 
-    @Override
-    public void after(Object target, Object[] args,
-            Object result, Throwable throwable) {
+
+    private void rewriteFirstConfigCenterRemoveRest(ConfigManager configManager,
+            Collection<ConfigCenterConfig> centers,
+            String polarisAddress,
+            Map<String, String> polarisParameters) {
+        ConfigCenterConfig first = pickFirstConfigCenter(centers);
+        if (first == null) {
+            return;
+        }
+
+        LOGGER.info("Rewriting first ConfigCenter [" + first.getProtocol()
+                + "://" + first.getAddress() + "] -> ["
+                + DubboConstants.POLARIS_PROTOCOL + "://"
+                + polarisAddress + "]");
+        applyPolarisFields(first, polarisAddress, polarisParameters);
+
+        // 收集"要删的"到独立 list,避免 CME
+        List<ConfigCenterConfig> toRemove =
+                new ArrayList<ConfigCenterConfig>();
+        for (ConfigCenterConfig cc : centers) {
+            if (cc != first) {
+                toRemove.add(cc);
+            }
+        }
+        for (ConfigCenterConfig cc : toRemove) {
+            LOGGER.info("Removing extra ConfigCenter ["
+                    + cc.getProtocol() + "://" + cc.getAddress() + "]");
+            configManager.removeConfig(cc);
+        }
+    }
+
+    /**
+     * 选首位: 优先 id 等于 Dubbo 自动赋的 ConfigCenterBean#0;
+     * 找不到退回 iterator().next()。
+     */
+    private ConfigCenterConfig pickFirstConfigCenter(
+            Collection<ConfigCenterConfig> centers) {
+        if (centers == null || centers.isEmpty()) {
+            return null;
+        }
+        for (ConfigCenterConfig cc : centers) {
+            if (DubboConstants.AUTO_CONFIG_CENTER_ID_PREFIX_ZERO
+                    .equals(cc.getId())) {
+                return cc;
+            }
+        }
+        return centers.iterator().next();
+    }
+
+    private void disableMetadataReport() {
         ConfigManager configManager =
                 ApplicationModel.getConfigManager();
+        Collection<MetadataReportConfig> metadataReportConfigs =
+                configManager.getMetadataConfigs();
+        if (metadataReportConfigs != null && !metadataReportConfigs.isEmpty()) {
+            // remove all existing metadata report configs
+            // polaris does not support metadata report yet
+            metadataReportConfigs.clear();
+        }
+
+        Optional<ApplicationConfig> applicationConfig =
+                configManager.getApplication();
+        // 注意: ApplicationConfig.metadataType 在用户未配置
+        // dubbo.application.metadata-type 时为 null,
+        if (applicationConfig.isPresent()
+                && "remote".equals(applicationConfig.get().getMetadataType())) {
+            LOGGER.warning("metadata-type is remote, change to local "
+                    + "cause polaris does not support remote metadata report yet");
+            applicationConfig.get().setMetadataType("local");
+        }
         Collection<RegistryConfig> registries =
                 configManager.getRegistries();
-
-        // 分支 0: 已有 polaris registry → no-op
-        RegistryConfig existingPolaris = findPolaris(registries);
-        if (existingPolaris != null) {
-            LOGGER.info("Polaris registry already present (id="
-                    + existingPolaris.getId() + ", address="
-                    + existingPolaris.getAddress()
-                    + "), agent skips registry rewrite");
-            return;
-        }
-
-        // 分支 1: 空列表 — 加一个默认 polaris
         if (registries == null || registries.isEmpty()) {
-            LOGGER.info("No registries found in ConfigManager, "
-                    + "adding polaris registry");
-            addPolarisRegistry(configManager);
             return;
         }
+        for (RegistryConfig registryConfig : registries) {
+            // 禁用 metadata report / config center,以及取消默认标识
+            registryConfig.setUseAsMetadataCenter(false);
+            registryConfig.setUseAsConfigCenter(false);
+        }
+    }
 
-        // 分支 2: 改写首位为 polaris,删除其余
-        rewriteFirstRemoveRest(configManager, registries);
+    private void modifyExistedRegistry() {
+        // fail-safe 总入口: 与 injectConfigCenter() 同样的语义 —
+        // plugin 任何异常都不应阻塞 DubboBootstrap.initialize() 主流程,
+        // 否则会让用户应用直接启动失败。
+        try {
+            ConfigManager configManager =
+                    ApplicationModel.getConfigManager();
+            Collection<RegistryConfig> registries =
+                    configManager.getRegistries();
+
+            // 加一个默认 polaris (前移到 for 循环之前,
+            // 避免 registries == null 时 for-each 直接 NPE)
+            if (registries == null || registries.isEmpty()) {
+                LOGGER.info("No registries found in ConfigManager, "
+                        + "adding polaris registry");
+                addPolarisRegistry(configManager);
+                return;
+            }
+
+            // 分支 0: 已有 polaris registry → no-op
+            RegistryConfig existingPolaris = findPolaris(registries);
+            if (existingPolaris != null) {
+                LOGGER.info("Polaris registry already present (id="
+                        + existingPolaris.getId() + ", address="
+                        + existingPolaris.getAddress()
+                        + "), agent skips registry rewrite");
+                return;
+            }
+
+            // 分支 2: 改写首位为 polaris,删除其余
+            rewriteFirstRemoveRest(configManager, registries);
+        } catch (Throwable th) {
+            LOGGER.warning("Polaris registry rewrite failed; "
+                    + "falling back to original registry: "
+                    + th.getMessage());
+        }
     }
 
     private void addPolarisRegistry(
@@ -166,9 +265,7 @@ public class DubboBootstrapInterceptor implements Interceptor {
      * 改写"首位"为 polaris,删除其余。
      *
      * <p>"首位"定义:优先选 id == "org.apache.dubbo.config.RegistryConfig#0"
-     * 的 RegistryConfig (Dubbo 在用户未显式 setId 时按声明顺序自动赋的 id,
-     * 跨 JVM 稳定);若找不到 #0,退回 iterator().next() (HashMap 顺序,
-     * 跨 JVM 不稳定,作为兼容 fallback)。</p>
+     * 的 RegistryConfig (对应dubbo.registry.address的配置);若找不到 #0,退回 iterator().next() </p>
      *
      * <p>关键: 删除时必须先把要删的 collect 到独立 list,再统一调
      * removeConfig,否则 fail-fast iterator 抛 ConcurrentModificationException
@@ -185,7 +282,7 @@ public class DubboBootstrapInterceptor implements Interceptor {
         Map<String, String> params =
                 DubboConfigProvider.getRegistryParameters();
 
-        RegistryConfig first = pickFirst(registries);
+        RegistryConfig first = pickFirstRegistry(registries);
         if (first == null) {
             return; // 防御性: 调用方已保证非空
         }
@@ -219,7 +316,7 @@ public class DubboBootstrapInterceptor implements Interceptor {
      * 选首位: 优先 id 等于 Dubbo 自动赋的 "...RegistryConfig#0";
      * 找不到退回 iterator().next()。
      */
-    private RegistryConfig pickFirst(Collection<RegistryConfig> registries) {
+    private RegistryConfig pickFirstRegistry(Collection<RegistryConfig> registries) {
         if (registries == null || registries.isEmpty()) {
             return null;
         }
@@ -249,23 +346,6 @@ public class DubboBootstrapInterceptor implements Interceptor {
         }
     }
 
-    /**
-     * 把一个 ConfigCenterConfig 重置为 polaris 协议。
-     *
-     * <p>字段处理清单:
-     * <ul>
-     *   <li>protocol → "polaris"</li>
-     *   <li>address  → polarisAddress</li>
-     *   <li>port/cluster/username/password → null (清掉用户原配残值)</li>
-     *   <li>parameters → 重置为空 Map 后 merge 进 polarisParameters</li>
-     *   <li>namespace/group → 完全不动 (用户业务语义,plugin 不越权)</li>
-     *   <li>configFile/appConfigFile/timeout/highestPriority/check → 保留</li>
-     * </ul>
-     *
-     * <p>关键顺序: <strong>必须先 setParameters(new HashMap) 清空</strong>,
-     * 再 setProtocol、setAddress;否则 setAddress 内部会 URL.valueOf 解析
-     * 然后 updateParameters(...) 把残留参数拼回来。</p>
-     */
     private void applyPolarisFields(ConfigCenterConfig cc,
             String polarisAddress,
             Map<String, String> polarisParameters) {
@@ -287,8 +367,6 @@ public class DubboBootstrapInterceptor implements Interceptor {
         if (!polarisParameters.isEmpty()) {
             mergeParameters(cc, polarisParameters);
         }
-        // 6. namespace / group / configFile / appConfigFile / timeout /
-        //    highestPriority / check 不动 — 由用户 application.yml 决定
     }
 
     /**

--- a/polaris-agent-plugins/dubbo-plugins/dubbo-2.7.x-plugin/src/test/java/cn/polarismesh/agent/plugin/dubbo27/interceptor/DubboBootstrapInterceptorConfigCenterTest.java
+++ b/polaris-agent-plugins/dubbo-plugins/dubbo-2.7.x-plugin/src/test/java/cn/polarismesh/agent/plugin/dubbo27/interceptor/DubboBootstrapInterceptorConfigCenterTest.java
@@ -155,8 +155,10 @@ public class DubboBootstrapInterceptorConfigCenterTest {
     }
 
     @Test
-    public void testBefore_mixedPolarisAndNacos_onlyNacosRewritten() {
-        // 同时有 polaris 和 nacos,只改写 nacos,polaris 完全不动
+    public void testBefore_mixedPolarisAndNacos_skipsRewrite() {
+        // 同时有 polaris 和 nacos: plugin 选择不越权——发现已存在 polaris ConfigCenter
+        // 即直接 no-op,既不改写 nacos,也不删除 nacos。语义是"用户自己已经显式声明了
+        // polaris 配置,我们保持现状,任何混合配置都视为用户故意为之"。
         ConfigCenterConfig polarisCc = new ConfigCenterConfig();
         polarisCc.setId("cc-polaris");
         polarisCc.setProtocol(DubboConstants.POLARIS_PROTOCOL);
@@ -174,15 +176,20 @@ public class DubboBootstrapInterceptorConfigCenterTest {
         interceptor.before(new Object(), null);
 
         // polaris 不变
+        Assertions.assertThat(polarisCc.getProtocol())
+                .isEqualTo(DubboConstants.POLARIS_PROTOCOL);
         Assertions.assertThat(polarisCc.getAddress())
                 .isEqualTo("polaris://10.0.0.1:8093");
         Assertions.assertThat(polarisCc.getNamespace())
                 .isEqualTo("polaris-ns");
-        // nacos 改写为 polaris
-        Assertions.assertThat(nacos.getProtocol())
-                .isEqualTo(DubboConstants.POLARIS_PROTOCOL);
+        // nacos 也不变 (不改写、不删除)
+        Assertions.assertThat(nacos.getProtocol()).isEqualTo("nacos");
         Assertions.assertThat(nacos.getAddress())
-                .isEqualTo("polaris://127.0.0.1:8093");
+                .isEqualTo("nacos://2.2.2.2:8848");
+        // ConfigManager 仍保有两条 ConfigCenter
+        Collection<ConfigCenterConfig> centers =
+                ApplicationModel.getConfigManager().getConfigCenters();
+        Assertions.assertThat(centers).hasSize(2);
     }
 
     @Test

--- a/polaris-agent-plugins/dubbo-plugins/dubbo-2.7.x-plugin/src/test/java/cn/polarismesh/agent/plugin/dubbo27/interceptor/DubboBootstrapInterceptorTest.java
+++ b/polaris-agent-plugins/dubbo-plugins/dubbo-2.7.x-plugin/src/test/java/cn/polarismesh/agent/plugin/dubbo27/interceptor/DubboBootstrapInterceptorTest.java
@@ -194,7 +194,7 @@ public class DubboBootstrapInterceptorTest {
     }
 
     @Test
-    public void testAfter_pickFirstFallback_whenNoZeroId() {
+    public void testAfter_pickFirstRegistryFallback_whenNoZeroId() {
         // 多个 registry 但都不是 #0 id → fallback 到 iterator().next()
         // (HashMap 顺序不稳定,只断言"剩 1 个 polaris" + "无异常")。
         RegistryConfig nacos = new RegistryConfig();


### PR DESCRIPTION
**Please provide issue(s) of this PR:**
Fixes #
dubbo2.7初始化时，如果没有配置metadata-report项，默认会选取注册中心配置作为元数据上报地址。
<img width="837" height="358" alt="Clipboard_Screenshot_1781169076" src="https://github.com/user-attachments/assets/8201b707-3fe9-4f5a-911c-4dadd9559d9b" />
北极星目前不支持dubbo2.7的元数据上报功能。此次pr会让javaagent在dubbo服务初始化前，清空元数据上报能力，禁用注册中心地址为元数据中心，并设置metadataType为local。


**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Docs
- [ ] Discovery
- [ ] Route
- [ ] RateLimit
- [ ] CircuitBreaker
- [ ] Test and Release

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any user-facing changes. This may include API changes, behavior changes, performance improvements, etc.
